### PR TITLE
Includes dependencies for chai and supertest

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "test": "env NODE_ENV=test mocha --recursive tests",
+    "test": "env NODE_ENV=test mocha --recursive tests --timeout 5000",
     "start-server": "env NODE_ENV=production forever -o ./app/temp/logs/output.log -e ./app/temp/logs/error.log start ./app/index.js",
     "stop-server": "env NODE_ENV=production forever stop app/index.js"
   },
@@ -12,7 +12,9 @@
     "@onehilltech/blueprint-gatekeeper": "^0.68.2",
     "@onehilltech/blueprint-mongodb": "^0.35.7",
     "jsonwebtoken": "^8.1.0",
-    "sendmail": "^1.2.0"
+    "sendmail": "^1.2.0",
+    "chai": "*",
+    "supertest": "*"
   },
   "devDependencies": {},
   "license": "Apache-2.0",


### PR DESCRIPTION
Also increased timeout for mocha tests. At time of writing, they fail because the default timeout for the beforeEach and before function hooks is 2 seconds.